### PR TITLE
Update library version, fix rust-analyzer warning, update api version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "tfl-api-wrapper"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "derive_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "TFL API Wrapper"
 name = "tfl-api-wrapper"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Shantanu Deshpande <shantanud106@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/tests/tfl.rs
+++ b/tests/tfl.rs
@@ -2,7 +2,7 @@
 mod tests {
     use std::{env, vec};
 
-    use std::collections::HashMap;
+    
     use strum::IntoEnumIterator;
     use tfl_api_wrapper::models::{self};
     use tfl_api_wrapper::{linemodels, Client, RequestBuilder};
@@ -15,7 +15,7 @@ mod tests {
     async fn it_is_expected_version() {
         let client = get_client();
         let ver = client.api_version().fetch().await.unwrap();
-        assert_eq!(ver.version, "master.5892\r\n");
+        assert_eq!(ver.version, "master.5909\r\n");
     }
 
     #[tokio::test]


### PR DESCRIPTION
* Update library version for publishing
* Fix rust-analyzer warning in test file
* Update TFL API version